### PR TITLE
Enforced per-world account checks in command permissions

### DIFF
--- a/src/main/java/net/thenextlvl/economist/command/AccountCommand.java
+++ b/src/main/java/net/thenextlvl/economist/command/AccountCommand.java
@@ -46,7 +46,7 @@ public class AccountCommand {
                 .then(Commands.argument("player", CustomArgumentTypes.cachedOfflinePlayer())
                         .requires(stack -> stack.getSender().hasPermission("economist.account.create.others"))
                         .then(Commands.argument("world", ArgumentTypes.world())
-                                .requires(stack -> stack.getSender().hasPermission("economist.account.create.world"))
+                                .requires(stack -> stack.getSender().hasPermission("economist.account.create.world") && plugin.config.accounts.perWorld)
                                 .executes(context -> {
                                     var player = context.getArgument("player", OfflinePlayer.class);
                                     var world = context.getArgument("world", World.class);
@@ -59,7 +59,7 @@ public class AccountCommand {
                 .then(Commands.argument("players", ArgumentTypes.players())
                         .requires(stack -> stack.getSender().hasPermission("economist.account.create.others"))
                         .then(Commands.argument("world", ArgumentTypes.world())
-                                .requires(stack -> stack.getSender().hasPermission("economist.account.create.world"))
+                                .requires(stack -> stack.getSender().hasPermission("economist.account.create.world") && plugin.config.accounts.perWorld)
                                 .executes(context -> {
                                     var players = context.getArgument("players", PlayerSelectorArgumentResolver.class);
                                     var world = context.getArgument("world", World.class);
@@ -84,7 +84,7 @@ public class AccountCommand {
                 .then(Commands.argument("player", CustomArgumentTypes.cachedOfflinePlayer())
                         .requires(stack -> stack.getSender().hasPermission("economist.account.delete.others"))
                         .then(Commands.argument("world", ArgumentTypes.world())
-                                .requires(stack -> stack.getSender().hasPermission("economist.account.delete.world"))
+                                .requires(stack -> stack.getSender().hasPermission("economist.account.delete.world") && plugin.config.accounts.perWorld)
                                 .executes(context -> {
                                     var player = context.getArgument("player", OfflinePlayer.class);
                                     var world = context.getArgument("world", World.class);
@@ -97,7 +97,7 @@ public class AccountCommand {
                 .then(Commands.argument("players", ArgumentTypes.players())
                         .requires(stack -> stack.getSender().hasPermission("economist.account.delete.others"))
                         .then(Commands.argument("world", ArgumentTypes.world())
-                                .requires(stack -> stack.getSender().hasPermission("economist.account.delete.world"))
+                                .requires(stack -> stack.getSender().hasPermission("economist.account.delete.world") && plugin.config.accounts.perWorld)
                                 .executes(context -> {
                                     var players = context.getArgument("players", PlayerSelectorArgumentResolver.class);
                                     var world = context.getArgument("world", World.class);

--- a/src/main/java/net/thenextlvl/economist/command/BalanceCommand.java
+++ b/src/main/java/net/thenextlvl/economist/command/BalanceCommand.java
@@ -26,7 +26,7 @@ public class BalanceCommand {
                 .then(Commands.argument("player", CustomArgumentTypes.cachedOfflinePlayer())
                         .requires(stack -> stack.getSender().hasPermission("economist.balance.others"))
                         .then(Commands.argument("world", ArgumentTypes.world())
-                                .requires(stack -> stack.getSender().hasPermission("economist.balance.world"))
+                                .requires(stack -> stack.getSender().hasPermission("economist.balance.world") && plugin.config.accounts.perWorld)
                                 .executes(context -> {
                                     var player = context.getArgument("player", OfflinePlayer.class);
                                     var world = context.getArgument("world", World.class);

--- a/src/main/java/net/thenextlvl/economist/command/BalanceTopCommand.java
+++ b/src/main/java/net/thenextlvl/economist/command/BalanceTopCommand.java
@@ -29,7 +29,7 @@ public class BalanceTopCommand {
                 .requires(stack -> stack.getSender().hasPermission("economist.balance-top"))
                 .then(Commands.argument("page", IntegerArgumentType.integer(1))
                         .then(Commands.argument("world", ArgumentTypes.world())
-                                .requires(stack -> stack.getSender().hasPermission("economist.balance-top.world"))
+                                .requires(stack -> stack.getSender().hasPermission("economist.balance-top.world") && plugin.config.accounts.perWorld)
                                 .executes(context -> {
                                     var world = context.getArgument("world", World.class);
                                     var page = context.getArgument("page", int.class);

--- a/src/main/java/net/thenextlvl/economist/command/EconomyCommand.java
+++ b/src/main/java/net/thenextlvl/economist/command/EconomyCommand.java
@@ -52,21 +52,25 @@ public class EconomyCommand {
     private static ArgumentBuilder<CommandSourceStack, ?> reset(EconomistPlugin plugin) {
         return Commands.literal("reset")
                 .then(Commands.argument("player", CustomArgumentTypes.cachedOfflinePlayer())
-                        .then(Commands.argument("world", ArgumentTypes.world()).executes(context -> {
-                            var player = context.getArgument("player", OfflinePlayer.class);
-                            var world = context.getArgument("world", World.class);
-                            return execute(context, "balance.reset.world", List.of(player), plugin.config.startBalance, world, Account::setBalance, plugin);
-                        })).executes(context -> {
+                        .then(Commands.argument("world", ArgumentTypes.world())
+                                .requires(stack -> plugin.config.accounts.perWorld)
+                                .executes(context -> {
+                                    var player = context.getArgument("player", OfflinePlayer.class);
+                                    var world = context.getArgument("world", World.class);
+                                    return execute(context, "balance.reset.world", List.of(player), plugin.config.startBalance, world, Account::setBalance, plugin);
+                                })).executes(context -> {
                             var player = context.getArgument("player", OfflinePlayer.class);
                             return execute(context, "balance.reset", List.of(player), plugin.config.startBalance, null, Account::setBalance, plugin);
                         }))
                 .then(Commands.argument("players", ArgumentTypes.players())
-                        .then(Commands.argument("world", ArgumentTypes.world()).executes(context -> {
-                            var players = context.getArgument("players", PlayerSelectorArgumentResolver.class);
-                            var resolve = players.resolve(context.getSource());
-                            var world = context.getArgument("world", World.class);
-                            return execute(context, "balance.reset.world", resolve, plugin.config.startBalance, world, Account::setBalance, plugin);
-                        })).executes(context -> {
+                        .then(Commands.argument("world", ArgumentTypes.world())
+                                .requires(stack -> plugin.config.accounts.perWorld)
+                                .executes(context -> {
+                                    var players = context.getArgument("players", PlayerSelectorArgumentResolver.class);
+                                    var resolve = players.resolve(context.getSource());
+                                    var world = context.getArgument("world", World.class);
+                                    return execute(context, "balance.reset.world", resolve, plugin.config.startBalance, world, Account::setBalance, plugin);
+                                })).executes(context -> {
                             var players = context.getArgument("players", PlayerSelectorArgumentResolver.class);
                             var resolve = players.resolve(context.getSource());
                             return execute(context, "balance.reset", resolve, plugin.config.startBalance, null, Account::setBalance, plugin);
@@ -74,28 +78,32 @@ public class EconomyCommand {
     }
 
     private static ArgumentBuilder<CommandSourceStack, ?> create(String command, String successMessage, String successMessageWorld,
-                                                          BiFunction<Account, Number, BigDecimal> function, Double minimum, EconomistPlugin plugin) {
+                                                                 BiFunction<Account, Number, BigDecimal> function, Double minimum, EconomistPlugin plugin) {
         return Commands.literal(command)
                 .then(Commands.argument("player", CustomArgumentTypes.cachedOfflinePlayer())
                         .then(Commands.argument("amount", DoubleArgumentType.doubleArg(minimum))
-                                .then(Commands.argument("world", ArgumentTypes.world()).executes(context -> {
-                                    var player = context.getArgument("player", OfflinePlayer.class);
-                                    var amount = context.getArgument("amount", Double.class);
-                                    var world = context.getArgument("world", World.class);
-                                    return execute(context, successMessageWorld, List.of(player), amount, world, function, plugin);
-                                })).executes(context -> {
+                                .then(Commands.argument("world", ArgumentTypes.world())
+                                        .requires(stack -> plugin.config.accounts.perWorld)
+                                        .executes(context -> {
+                                            var player = context.getArgument("player", OfflinePlayer.class);
+                                            var amount = context.getArgument("amount", Double.class);
+                                            var world = context.getArgument("world", World.class);
+                                            return execute(context, successMessageWorld, List.of(player), amount, world, function, plugin);
+                                        })).executes(context -> {
                                     var player = context.getArgument("player", OfflinePlayer.class);
                                     var amount = context.getArgument("amount", Double.class);
                                     return execute(context, successMessage, List.of(player), amount, null, function, plugin);
                                 })))
                 .then(Commands.argument("players", ArgumentTypes.players())
                         .then(Commands.argument("amount", DoubleArgumentType.doubleArg(minimum))
-                                .then(Commands.argument("world", ArgumentTypes.world()).executes(context -> {
-                                    var players = context.getArgument("players", PlayerSelectorArgumentResolver.class);
-                                    var amount = context.getArgument("amount", Double.class);
-                                    var world = context.getArgument("world", World.class);
-                                    return execute(context, successMessageWorld, List.copyOf(players.resolve(context.getSource())), amount, world, function, plugin);
-                                })).executes(context -> {
+                                .then(Commands.argument("world", ArgumentTypes.world())
+                                        .requires(stack -> plugin.config.accounts.perWorld)
+                                        .executes(context -> {
+                                            var players = context.getArgument("players", PlayerSelectorArgumentResolver.class);
+                                            var amount = context.getArgument("amount", Double.class);
+                                            var world = context.getArgument("world", World.class);
+                                            return execute(context, successMessageWorld, List.copyOf(players.resolve(context.getSource())), amount, world, function, plugin);
+                                        })).executes(context -> {
                                     var players = context.getArgument("players", PlayerSelectorArgumentResolver.class);
                                     var amount = context.getArgument("amount", Double.class);
                                     return execute(context, successMessage, List.copyOf(players.resolve(context.getSource())), amount, null, function, plugin);
@@ -103,8 +111,8 @@ public class EconomyCommand {
     }
 
     private static int execute(CommandContext<CommandSourceStack> context, String successMessage,
-                        Collection<? extends OfflinePlayer> players, Number amount, @Nullable World world,
-                        BiFunction<Account, Number, BigDecimal> function, EconomistPlugin plugin) {
+                               Collection<? extends OfflinePlayer> players, Number amount, @Nullable World world,
+                               BiFunction<Account, Number, BigDecimal> function, EconomistPlugin plugin) {
         var sender = context.getSource().getSender();
         var locale = sender instanceof Player p ? p.locale() : Locale.US;
         if (!players.isEmpty()) players.forEach(player -> (world != null

--- a/src/main/java/net/thenextlvl/economist/command/PayCommand.java
+++ b/src/main/java/net/thenextlvl/economist/command/PayCommand.java
@@ -33,7 +33,7 @@ public class PayCommand {
                             var player = context.getArgument("player", OfflinePlayer.class);
                             return pay(context, List.of(player), null, plugin);
                         }).then(Commands.argument("world", ArgumentTypes.world())
-                                .requires(stack -> stack.getSender().hasPermission("economist.pay.world"))
+                                .requires(stack -> stack.getSender().hasPermission("economist.pay.world") && plugin.config.accounts.perWorld)
                                 .executes(context -> {
                                     var player = context.getArgument("player", OfflinePlayer.class);
                                     var world = context.getArgument("world", World.class);
@@ -44,7 +44,7 @@ public class PayCommand {
                             var players = context.getArgument("players", PlayerSelectorArgumentResolver.class);
                             return pay(context, new ArrayList<>(players.resolve(context.getSource())), null, plugin);
                         }).then(Commands.argument("world", ArgumentTypes.world())
-                                .requires(stack -> stack.getSender().hasPermission("economist.pay.world"))
+                                .requires(stack -> stack.getSender().hasPermission("economist.pay.world") && plugin.config.accounts.perWorld)
                                 .executes(context -> {
                                     var players = context.getArgument("players", PlayerSelectorArgumentResolver.class);
                                     var world = context.getArgument("world", World.class);


### PR DESCRIPTION
Added `plugin.config.accounts.perWorld` validation to ensure commands like balance, pay, and account management respect per-world configurations.